### PR TITLE
Enforce -no-pie for compiling LTP tests on 18.04+ platforms

### DIFF
--- a/ltp/Makefile
+++ b/ltp/Makefile
@@ -19,7 +19,7 @@ $(SRCDIR)/configure: $(SRCDIR).tar.xz
 	tar -xmJf $<
 
 $(BUILDDIR)/runltp: $(SRCDIR)/configure
-	cd $(SRCDIR) && ./configure
+	cd $(SRCDIR) && ./configure CFLAGS=-no-pie
 	cd $(SRCDIR) && make all
 	cd $(SRCDIR) && make "DESTDIR=$(PWD)" SKIP_IDCHECK=1 install
 	patch -d $(dir $@) < runltp.patch


### PR DESCRIPTION
Some LTP tests (e.g., `brk01`) assumes the executables to be position-independent. As a result, these tests can fail on Ubuntu 18.04+ if `-pie` is adopted as the default for GCC 5+. To stablize these tests, we need to force `-no-pie` when compiling LTP binaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/4)
<!-- Reviewable:end -->
