### PR TITLE
[LTP] Disable two LTP tests that fail on GLIBC 2.23 and 2.27

### DIFF
--- a/ltp/PASSED
+++ b/ltp/PASSED
@@ -843,7 +843,6 @@ select01,1
 select02,1
 semctl01,2
 semctl01,3
-semctl07,4
 semget02,2
 semget03,1
 semop01,1
@@ -1037,7 +1036,6 @@ sysconf01,7
 sysconf01,8
 sysconf01,9
 sysconf01,10
-sysconf01,11
 sysconf01,12
 sysconf01,13
 sysconf01,14


### PR DESCRIPTION
Disabling two LTP tests that are not supposed to work at the first place:
- `semctl07` requires support for `IPC_STAT` (getting IPC statistics), which is not implemented currently.
- `sysconf01(SC_TZNAME_MAX)` is not supported either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/5)
<!-- Reviewable:end -->
