### PR TITLE
[ltp] enable fstatat01,1  fstat03,3

### DIFF
--- a/ltp/PASSED
+++ b/ltp/PASSED
@@ -219,7 +219,9 @@ fstat01,1
 fstat01_64,1
 fstat03,1
 fstat03_64,1
+fstatat01,1
 fstatat01,2
+fstatat01,3
 fstatat01,4
 fstatat01,5
 fstatat01,6


### PR DESCRIPTION
graphene #672 enables them.
If newfstatat system call isn't supported,
fxstatat function of glibc falls back to lstat/stat system call.
That's the reason why some of fstatat01 passed so far.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/7)
<!-- Reviewable:end -->
