### PR TITLE
[LTP] Drop the test for SIGUNUSED

### DIFF
--- a/ltp/PASSED
+++ b/ltp/PASSED
@@ -975,7 +975,6 @@ signal03,27
 signal03,28
 signal03,29
 signal03,30
-signal03,31
 signal04,1
 signal04,2
 signal04,3
@@ -1034,7 +1033,6 @@ signal05,27
 signal05,28
 signal05,29
 signal05,30
-signal05,31
 signal06,1
 signal06,2
 signal06,3


### PR DESCRIPTION
It is deprecated and compiled out on 18.04.  This manifests as a failure of the 31st test on signal03 and signal05.

The difference is this line in the code:

```
int siglist[] = { SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGIOT,
        SIGBUS, SIGFPE, SIGUSR1, SIGSEGV, SIGUSR2, SIGPIPE, SIGALRM,
        SIGTERM,
#ifdef SIGSTKFLT
        SIGSTKFLT,
#endif
        SIGCHLD, SIGCONT, SIGTSTP, SIGTTIN,
        SIGTTOU, SIGURG, SIGXCPU, SIGXFSZ, SIGVTALRM, SIGPROF,
        SIGWINCH, SIGIO, SIGPWR, SIGSYS,
#ifdef SIGUNUSED
        SIGUNUSED
#endif
};
```

This code generates the test list, and, on 18.04, the 31st entry is compiled out, but not on 16.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/9)
<!-- Reviewable:end -->
