### PR TITLE
[LTP] Remove flaky futex_wait03 and sigpending02 tests

### DIFF
--- a/ltp/PASSED
+++ b/ltp/PASSED
@@ -280,7 +280,6 @@ futex_wait01,1
 futex_wait01,2
 futex_wait01,3
 futex_wait01,4
-futex_wait03,1
 futex_wait04,1
 futex_wait05,1
 futex_wait05,2
@@ -1039,9 +1038,6 @@ signal06,3
 signal06,4
 signal06,5
 sigpending02,1
-sigpending02,2
-sigpending02,4
-sigpending02,5
 sigprocmask01,1
 sigsuspend01,1
 socket01,3


### PR DESCRIPTION
These tests were added in commit 6f64f3a but they are flaky. Removing them for now until we debug their bugs and fix them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/11)
<!-- Reviewable:end -->
