### PR TITLE
[GCC] Fix manifests of subprocesses to use same enclave size

### DIFF
--- a/gcc/as.manifest.template
+++ b/gcc/as.manifest.template
@@ -23,6 +23,8 @@ fs.mount.tmp.type = chroot
 fs.mount.tmp.path = /tmp
 fs.mount.tmp.uri = file:/tmp
 
+sgx.enclave_size = 1G
+
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2

--- a/gcc/cc1.manifest.template
+++ b/gcc/cc1.manifest.template
@@ -23,7 +23,7 @@ fs.mount.tmp.type = chroot
 fs.mount.tmp.path = /tmp
 fs.mount.tmp.uri = file:/tmp
 
-$(HUGERULE)
+sgx.enclave_size = 1G
 
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6

--- a/gcc/collect2.manifest.template
+++ b/gcc/collect2.manifest.template
@@ -23,6 +23,8 @@ fs.mount.tmp.type = chroot
 fs.mount.tmp.path = /tmp
 fs.mount.tmp.uri = file:/tmp
 
+sgx.enclave_size = 1G
+
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2

--- a/gcc/ld.manifest.template
+++ b/gcc/ld.manifest.template
@@ -23,7 +23,7 @@ fs.mount.tmp.type = chroot
 fs.mount.tmp.path = /tmp
 fs.mount.tmp.uri = file:/tmp
 
-sgx.enclave_size = 512M
+sgx.enclave_size = 1G
 
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6


### PR DESCRIPTION
Previously, GCC subprocesses' manifests had different enclave sizes. This conflicts with CPSTORE_DERANDOMIZATION macro which forces the child to allocate the checkpoint at the exact same memory region as parent. If parent has greater enclave size (in its manifest), it can allocate the checkpoint at region not available for child with smaller enclave size. This commit simply instructs all GCC subprocesses to allocate the same enclave size to side-step this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/14)
<!-- Reviewable:end -->
