### PR TITLE
Add Redis example

### DIFF
--- a/redis/Makefile
+++ b/redis/Makefile
@@ -1,0 +1,95 @@
+# Build Redis as follows:
+#
+# - make               -- create non-SGX no-debug-log manifest
+# - make SGX=1         -- create SGX no-debug-log manifest
+# - make SGX=1 DEBUG=1 -- create SGX debug-log manifest
+#
+# Any of these invocations clones Redis' git repository and builds Redis in
+# default configuration and in the latest-to-date (5.0.5) version.
+#
+# Use `make clean` to remove Graphene-generated files and `make distclean` to
+# additionally remove the cloned Redis git repository.
+
+################################# CONSTANTS ###################################
+
+# Relative path to Graphene root
+GRAPHENEDIR = ../../../../..
+
+SRCDIR = src
+COMMIT = 5.0.5
+
+ifeq ($(DEBUG),1)
+GRAPHENEDEBUG = inline
+else
+GRAPHENEDEBUG = none
+endif
+
+.PHONY: all
+all: redis-server redis-server.manifest pal_loader
+ifeq ($(SGX),1)
+all: redis-server.manifest.sgx
+endif
+
+############################## REDIS EXECUTABLE ###############################
+
+# Redis is built as usual, without any changes to the build process. The source
+# is cloned from a public GitHub repo (5.0.5 tag) and built via `make`. The
+# result of this build process is the final executable "src/redis-server".
+
+$(SRCDIR)/src/redis-server:
+	git clone --recursive https://github.com/antirez/redis $(SRCDIR)
+	cd $(SRCDIR) && git checkout $(COMMIT)
+	$(MAKE) -C $(SRCDIR)
+
+################################ REDIS MANIFEST ###############################
+
+# The template file contains almost all necessary information to run Redis
+# under Graphene / Graphene-SGX. We create redis.manifest (to be run under
+# non-SGX Graphene) by simply replacing variables in the template file via sed.
+
+redis-server.manifest: redis-server.manifest.template
+	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
+		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		$< > $@
+
+# Manifest for Graphene-SGX requires special "pal-sgx-sign" procedure. This
+# procedure measures all Redis dependencies (shared libraries and trusted
+# files), measures Redis code/data pages, and adds measurements in the
+# resulting manifest.sgx file (among other, less important SGX options).
+#
+# Additionally, Graphene-SGX requires EINITTOKEN and SIGSTRUCT objects (see
+# SGX hardware ABI, in particular EINIT instruction). The "pal-sgx-get-token"
+# script generates these objects and puts them in files .token and .sig
+# respectively. Note that filenames must be the same as the executable/manifest
+# name (i.e., "redis-server").
+
+redis-server.manifest.sgx: redis-server.manifest $(SRCDIR)/src/redis-server
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
+		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
+		-key $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem \
+		-manifest $< -output $@ \
+		-exec $(SRCDIR)/src/redis-server
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \
+		-output redis-server.token -sig redis-server.sig
+
+########################### COPIES OF EXECUTABLES #############################
+
+# Redis build process creates the final executable as src/redis-server. For
+# simplicity, copy it into our root directory.
+# Also, create a link to pal_loader for simplicity.
+
+redis-server: $(SRCDIR)/src/redis-server
+	cp $< $@
+
+pal_loader:
+	ln -s $(GRAPHENEDIR)/Runtime/pal_loader $@
+
+################################## CLEANUP ####################################
+
+.PHONY: clean
+clean:
+	$(RM) *.token *.sig *.manifest.sgx *.manifest pal_loader redis-server *.rdb
+
+.PHONY: distclean
+distclean: clean
+	$(RM) -r $(SRCDIR)

--- a/redis/README
+++ b/redis/README
@@ -1,0 +1,44 @@
+# Redis
+
+This directory contains the Makefile and the template manifest for the most
+recent version of Redis (as of this writing, version 5.0.5). This was tested
+on a machine with SGX v1 and Ubuntu 16.04.
+
+The Makefile and the template manifest contain extensive comments and are made
+self-explanatory. Please review them to gain understanding of Graphene-SGX
+and requirements for applications running under Graphene-SGX.
+
+# Quick Start
+
+```sh
+# build Redis and the final manifest
+make SGX=1
+
+# run original Redis against a benchmark (redis-benchmark supplied with Redis)
+./redis-server --save '' --protected-mode no &
+src/src/redis-benchmark
+kill %%
+
+# run Redis in non-SGX Graphene against a benchmark
+./pal_loader redis-server --save '' --protected-mode no &
+src/src/redis-benchmark
+kill %%
+
+# run Redis in Graphene-SGX against a benchmark
+SGX=1 ./pal_loader redis-server --save '' --protected-mode no &
+src/src/redis-benchmark
+kill %%
+```
+
+# Why this Redis configuration?
+
+Notice that we run Redis with two parameters: `save ''` and `protected-mode no`:
+
+- `save ''` disables saving DB to disk (both RDB snapshots and AOF logs). We
+  use this parameter to side-step some bugs in Graphene triggered during the
+  graceful shutdown of Redis.
+
+- `protected-mode no` allows clients to connect to Redis on any network
+  interface. Even though we use the loopback interface (which is always allowed
+  in Redis), Graphene hides this information. Therefore, we ask Redis to allow
+  clients on all interfaces.

--- a/redis/redis-server.manifest.template
+++ b/redis/redis-server.manifest.template
@@ -1,0 +1,156 @@
+# Redis manifest file example
+#
+# This manifest was prepared and tested on Ubuntu 16.04.
+
+################################## RUNNING ####################################
+
+# Executable to load into Graphene and run. Note that Graphene tries its best
+# to find the corresponding manifest file (by appending ".manifest" or
+# ".manifest.sgx") based on the executable name, and vice versa. Still, it is
+# required to have the explicit name of the executable here.
+loader.exec = file:redis-server
+
+################################## GRAPHENE ###################################
+
+# LibOS layer library of Graphene. There is currently only one implementation,
+# so it is always set to libsysdb.so. Note that GRAPHENEDIR macro is expanded
+# to relative path to Graphene repository in the Makefile as part of the
+# build process.
+loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
+
+# Show/hide debug log of Graphene ('inline' or 'none' respectively). Note that
+# GRAPHENEDEBUG macro is expanded to inline/none in the Makefile as part of the
+# build process.
+loader.debug_type = $(GRAPHENEDEBUG)
+
+################################# ENV VARS  ###################################
+
+# Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
+# applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
+# paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).
+#
+# In case of Redis:
+# - /lib is searched for Glibc libraries (ld, libc, libpthread)
+# - /lib/x86_64-linux-gnu is searched for Name Service Switch (NSS) libraries
+loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu
+
+################################# MOUNT FS  ###################################
+
+# General notes:
+# - There is only one supported type of mount points: 'chroot'.
+# - Directory names are (somewhat confusingly) prepended by 'file:'.
+# - Names of mount entries (lib, lib2, lib3) are irrelevant but must be unique.
+# - In-Graphene visible path names may be arbitrary but we reuse host-OS URIs
+#   for simplicity (except for the first 'lib' case).
+
+# Mount host-OS directory to Graphene glibc/runtime libraries (in 'uri') into
+# in-Graphene visible directory /lib (in 'path'). Note that GRAPHENEDIR macro
+# is expanded to relative path to Graphene repository in the Makefile as part
+# of the build process.
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+# Mount host-OS directory to Name Service Switch (NSS) libraries (in 'uri')
+# into in-Graphene visible directory /lib/x86_64-linux-gnu (in 'path').
+fs.mount.lib2.type = chroot
+fs.mount.lib2.path = /lib/x86_64-linux-gnu
+fs.mount.lib2.uri = file:/lib/x86_64-linux-gnu
+
+# Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
+# into in-Graphene visible directory /etc (in 'path').
+fs.mount.etc.type = chroot
+fs.mount.etc.path = /etc
+fs.mount.etc.uri = file:/etc
+
+################################## NETWORK ####################################
+
+# Allow binding on any network interface but only on port 6379. This is the
+# default port used by Redis. Note how a missing interface name means "any
+# interface".
+net.allow_bind.redisport = :6379
+
+############################### SGX: GENERAL ##################################
+
+# Set enclave size (somewhat arbitrarily) to 1024MB. Recall that SGX v1 requires
+# to specify enclave size at enclave creation time. If Redis exhausts these
+# 1024MB then it will start failing with random errors. Greater enclave sizes
+# result in longer startup times, smaller enclave sizes are not enough for
+# typical Redis workloads.
+sgx.enclave_size = 1024M
+
+# Set maximum number of in-enclave threads (somewhat arbitrarily) to 8. Recall
+# that SGX v1 requires to specify the maximum number of simulteneous threads at
+# enclave creation time.
+#
+# Note that internally Graphene may spawn two additional threads, one for IPC
+# and one for asynchronous events/alarms. Redis is technically single-threaded
+# but spawns couple additional threads to do background bookkeeping. Therefore,
+# specifying '8' allows to run a maximum of 6 Redis threads which is enough.
+sgx.thread_num = 8
+
+############################# SGX: TRUSTED LIBS ###############################
+
+# Specify all libraries used by Redis and its dependencies (including all
+# libraries which can be loaded at runtime via dlopen). The paths to libraries
+# are host-OS paths. These libraries will be searched for in in-Graphene visible
+# paths according to mount points above.
+#
+# As part of the build process, Graphene-SGX script (`pal-sgx-sign`) finds each
+# specified library, measures its hash, and outputs the hash in auto-generated
+# entry 'sgx.trusted_checksum.xxx' in auto-generated redis-server.manifest.sgx.
+# Note that this happens on the developer machine.
+#
+# At runtime, during loading of this library, Graphene-SGX measures its hash
+# and compares with the one specified in 'sgx.trusted_checksum.xxx'. If hashes
+# match, this library is trusted and allowed to be loaded and used. Note that
+# this happens on the client machine.
+
+# Glibc libraries. ld, libc, libm, libdl, librt provide common functionality;
+# pthread is needed because Redis spawns helper threads for bookkeeping.
+sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
+sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
+sgx.trusted_files.libdl = file:$(GRAPHENEDIR)/Runtime/libdl.so.2
+sgx.trusted_files.librt = file:$(GRAPHENEDIR)/Runtime/librt.so.1
+sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
+
+# Name Service Switch (NSS) libraries. Glibc calls these libraries as part of
+# name-service information gathering. libnss_{compat,files,nis} are the
+# most widely used libraries, at least on Ubuntu.
+# For more info, see 'man nsswitch.conf'.
+sgx.trusted_files.libnsscompat = file:/lib/x86_64-linux-gnu/libnss_compat.so.2
+sgx.trusted_files.libnssfiles  = file:/lib/x86_64-linux-gnu/libnss_files.so.2
+sgx.trusted_files.libnssnis  = file:/lib/x86_64-linux-gnu/libnss_nis.so.2
+
+# libNSL is a dependency of libnss_compat above. It is a good example of nested
+# library dependencies required by Graphene-SGX.
+sgx.trusted_files.libnsl = file:/lib/x86_64-linux-gnu/libnsl.so.1
+
+############################ SGX: TRUSTED FILES ###############################
+
+# Trusted no-library files include configuration files, read-only files, and
+# other static files. It is useful to specify such files here to make sure
+# they are not maliciously modified (modifications will be detected as hash
+# mismatch by Graphene-SGX).
+#
+# Redis by default does not use configuration files, so this section is empty.
+# sgx.trusted_files.config = file:<important-configuration-file>
+
+############################# SGX: ALLOWED FILES ###############################
+
+# Specify all non-static files used by app. These files may be accessed by
+# Graphene-SGX but their integrity is not verified (Graphene-SGX does not
+# measure their hashes). This may pose a security risk!
+
+# Name Service Switch (NSS) files. Glibc reads these files as part of name-
+# service information gathering. For more info, see 'man nsswitch.conf'.
+sgx.allowed_files.nsswitch  = file:/etc/nsswitch.conf
+sgx.allowed_files.ethers    = file:/etc/ethers
+sgx.allowed_files.hosts     = file:/etc/hosts
+sgx.allowed_files.group     = file:/etc/group
+sgx.allowed_files.passwd    = file:/etc/passwd
+
+# getaddrinfo(3) configuration file. Glibc reads this file to correctly find
+# network addresses. For more info, see 'man gai.conf'.
+sgx.allowed_files.gaiconf   = file:/etc/gai.conf


### PR DESCRIPTION
This PR adds a Redis example.

**Note!** There is still a TODO on inability to unset environment variables in Graphene. We first need to change it in Graphene code and then remove that comment from this Redis example.

**Note!** There is still a TODO on some error when Redis tries to finish the RDB snapshot file when gracefully shutting down (Ctrl-C). Currently we don't use the file system (`--save ''`) but this should be debugged and fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/17)
<!-- Reviewable:end -->
