### PR TITLE
[ltp] remove kill12 from PASSED

### DIFF
--- a/ltp/FLAKY
+++ b/ltp/FLAKY
@@ -45,3 +45,12 @@ Intermittent failure on Linux debug host
 recvmsg01,1
 recvmsg01,2
 
+# glibc issue:
+# Once glibc version is upgraded, this can be moved to PASSED
+#
+# old(2.19) glibc includes a work around for sleep(3)
+# which make kill12 unstable due to race condition.
+# The following glibc changeset removed such work around.
+#   commit 8c873bf0190740ac1102e13ff7aeb6c08048abfd
+#   Remove signal handling for nanosleep (bug 16364)
+kill12,1

--- a/ltp/PASSED
+++ b/ltp/PASSED
@@ -397,7 +397,6 @@ kill11,20
 kill11,21
 kill11,22
 kill11,23
-kill12,1
 listen01,1
 listen01,2
 llseek02,1


### PR DESCRIPTION
kill12 is unstable with glibc-2.19. It's glibc issue.
remove kill12 for glibc-2.19
TODO: move kill12 to PASSED once glibc version is upgraded.
the changeset of glibc is
> commit 8c873bf0190740ac1102e13ff7aeb6c08048abfd
>    Remove signal handling for nanosleep (bug 16364)

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/18)
<!-- Reviewable:end -->
