### PR TITLE
[LTP] Increase timeout for asyncio02

### DIFF
--- a/ltp/TIMEOUTS
+++ b/ltp/TIMEOUTS
@@ -4,6 +4,7 @@ alarm02,40
 alarm03,40
 alarm05,40
 alarm06,16
+asyncio02,80
 brk01,40
 chmod02,40
 clock_nanosleep01,40


### PR DESCRIPTION
Previously, we had an issue with one of the Jenkins worker machines, `slave-pepe`. A single LTP test called `asyncio02` failed on this machine constantly.

The  result of the investigation showed that:
1. `asyncio02` does not fail but hangs, i.e., the timeout in ltp/fetch.py is exceeded (and this test doesn't have a special timeout, so it uses the default timeout of 30 seconds).
2. `slave-pepe` is up to 2X slower than each of the other Jenkins machines. For example, the run of my test PR takes 3-4 minutes on other nodes but 8 minutes on slave-pepe. (Turns out `slave-pepe` is the only machine with a slow HDD drive instead of SSD).
3. The combination of 1 and 2 leads to `asyncio02` not finishing in 30 seconds, so LTP reports it as hanged which is reported in our log as "not passed".

This PR simply adds an 80-second timeout for `asyncio02`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/23)
<!-- Reviewable:end -->
