### PR TITLE
include Makefile.Test instead of Makefile and remove level variable

### DIFF
--- a/apache/Makefile
+++ b/apache/Makefile
@@ -26,8 +26,7 @@ clean-extra = clean-apache
 
 extra_rules = -e 's:\$$(HOST):$(HOST):g' -e 's:\$$(PORT):$(PORT):g'
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 .PHONY: build-apache
 build-apache: $(INSTALL_DIR)/bin/httpd $(INSTALL_DIR)/modules/libphp5.so

--- a/bash/Makefile
+++ b/bash/Makefile
@@ -3,8 +3,7 @@ BASH_DIR = bash-4.1
 manifests = $(addsuffix .manifest,bash ls cp rm cat date)
 exec_target = $(manifests)
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 $(bash_src): $(BASH_DIR).tar.gz
 	tar -xmzf $<

--- a/busybox/Makefile
+++ b/busybox/Makefile
@@ -1,8 +1,7 @@
 exec_target = busybox.manifest busybox_nofork.manifest
 target = busybox busybox_gdb busybox_nofork busybox_nofork_gdb
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 BUSYBOX_DIR = busybox-1.23.1
 

--- a/curl/Makefile
+++ b/curl/Makefile
@@ -5,8 +5,7 @@ exec_target = $(manifests)
 
 clean-extra += clean-tmp
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 clean-tmp:
 	rm -f curl.manifest.sgx

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -11,8 +11,7 @@ extra_rules = \
 	-e 's:\$$(GCCDIR):$(patsubst %/cc1,%,$(shell gcc -print-file-name=cc1)):g' \
 	-e 's:\$$(HUGERULE):$(if $(HUGE),$(huge_rule),):g'
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 GCC_VER = 4.8.4
 BINUTILS_VER = 2.20.1

--- a/lighttpd/Makefile
+++ b/lighttpd/Makefile
@@ -12,8 +12,7 @@ clean-extra = clean-others
 
 extra_rules = -e 's:\$$(HOST):$(HOST):g' -e 's:\$$(PORT):$(PORT):g'
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 LIGHTTPD-TARGETS = \
 	build/sbin/lighttpd \

--- a/lmbench/Makefile
+++ b/lmbench/Makefile
@@ -13,8 +13,7 @@ manifests = $(addprefix $(LINUXDIR),$(patsubst %.template,%,$(wildcard *.manifes
 target = $(lmbench_tests)
 clean-extra = clean-lmbench
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 export CC
 export CFLAGS

--- a/lmbench/Makefile.lmbench
+++ b/lmbench/Makefile.lmbench
@@ -10,8 +10,7 @@ lmbench_tests = lat_syscall lat_connect lat_fcntl \
 exec_target = $(lmbench_tests)
 target = $(manifests)
 
-level = ../../../../../
-include ../../../../../Makefile
+include ../../../../../Makefile.Test
 
 sh.manifest.sgx: /tmp/hello
 

--- a/ltp/Makefile
+++ b/ltp/Makefile
@@ -7,8 +7,7 @@ exec_target =
 
 clean-extra = clean-build
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 $(SRCDIR)/Makefile:
 	$(error "$(SRCDIR) is empty. Please run `git submodule update --init $(SRCDIR)` or download the LTP source code (https://github.com/linux-test-project/ltp) into $(SRCDIR).")

--- a/ltp/Makefile.testcases
+++ b/ltp/Makefile.testcases
@@ -4,8 +4,7 @@ testcases = $(filter-out $(wildcard *.*) $(patsubst %/,%,$(wildcard */)) Makefil
 exec_target = $(testcases)
 target = $(manifests) $(testcases) etc/nsswitch.conf etc/passwd
 
-level = ../../../../../../
-include ../../../../../../Makefile
+include ../../../../../../Makefile.Test
 
 $(addsuffix .template,$(manifests)): %: ../../../../%
 	ln -sf $< $@

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -13,8 +13,7 @@ clean-extra = clean-others
 
 extra_rules = -e 's:\$$(HOST):$(HOST):g' -e 's:\$$(PORT):$(PORT):g'
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 build-nginx: build/sbin/nginx
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -9,8 +9,7 @@ exec_target = $(manifests)
 extra_rules = -e 's:\$$(PYTHONDIR):$(PYTHON_INSTALL)/:g'
 clean-extra += clean-tmp
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 $(PYTHON_INSTALL)/bin/python: $(PYTHON_SRC)/Makefile
 	cd $(PYTHON_SRC) && $(MAKE)

--- a/r/Makefile
+++ b/r/Makefile
@@ -8,8 +8,7 @@ exec_target = $(manifests)
 
 extra_rules = -e 's:\$$(RDIR):$(R_INSTALL)/lib/R/:g'
 
-level = ../../
-include ../../Makefile
+include ../../Makefile.Test
 
 $(R_INSTALL)/lib/R/bin/exec/R: $(R_SRC)/Makefile
 	cd $(R_SRC) && $(MAKE)


### PR DESCRIPTION
LibOS/shim/test/Makefile has confusion that it's makefile for
the directory of LibOS/shim/test/ and common function for
each tests. It causes unnecessary complexity.
create Makefile.Test for common functions and use it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/25)
<!-- Reviewable:end -->
