### PR TITLE
[lighttpd] add dependency for .manifest.sgx

### DIFF
--- a/lighttpd/Makefile
+++ b/lighttpd/Makefile
@@ -15,10 +15,17 @@ extra_rules = -e 's:\$$(HOST):$(HOST):g' -e 's:\$$(PORT):$(PORT):g'
 level = ../../
 include ../../Makefile
 
-.PHONY: build-lighttpd
-build-lighttpd: build/sbin/lighttpd
+LIGHTTPD-TARGETS = \
+	build/sbin/lighttpd \
+	build/sbin/lighttpd-angel \
+	build/lib/mod_indexfile.so \
+	build/lib/mod_dirlisting.so \
+	build/lib/mod_staticfile.so
 
-build/sbin/lighttpd: $(SRCDIR)
+.PHONY: build-lighttpd
+build-lighttpd: $(LIGHTTPD-TARGETS)
+
+$(LIGHTTPD-TARGETS): $(SRCDIR)
 	cd $(SRCDIR) && ./configure --prefix=$(PWD)/build \
 		--with-openssl --without-pcre --without-zlib --without-bzip2
 	$(MAKE) -C $(SRCDIR)


### PR DESCRIPTION
.manifest.sgx actually has dependency on more binaries other than
lighttpd.
Once the dependencies are correctly calculated, make starts to fail
due to the lack of dependency.
Add those dependency.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/32)
<!-- Reviewable:end -->
