### PR TITLE
[LTP] Skip meaningless signal06 test

### DIFF
--- a/ltp/ltp.cfg
+++ b/ltp/ltp.cfg
@@ -2759,6 +2759,9 @@ skip = yes
 [signal01]
 skip = yes
 
+[signal06]
+skip = yes
+
 [signalfd01]
 skip = yes
 


### PR DESCRIPTION
The LTP test signal06 is a regression test for some obscure bug in older Linux kernels. It uses SIGHUP and SIGSEGV signals to test mprotect() of altstack. Since SIGHUP is completely ignored by Graphene, and altstack is not correctly emulated, and mprotect() doesn't work, this test never made sense for Graphene. This commit disables it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/53)
<!-- Reviewable:end -->
