### PR TITLE
[Nginx] Add test targets to Makefile for Jenkins

### DIFF
--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -165,6 +165,16 @@ $(RANDOM_DIR)/%.html:
 .PHONY: testdata
 testdata: $(TEST_DATA)
 
+# Targets to run Nginx
+
+.PHONY: start-native-server
+start-native-server: all
+	$(INSTALL_DIR)/sbin/nginx -c conf/nginx-graphene.conf
+
+.PHONY: start-graphene-server
+start-graphene-server: all
+	./pal_loader nginx.manifest -c conf/nginx-graphene.conf
+
 .PHONY: clean
 clean:
 	$(RM) *.manifest *.manifest.sgx *.token *.sig pal_loader OUTPUT result-* nginx-ldd tmp

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -37,3 +37,11 @@ kill -SIGINT %%
 # you can also test the server using other utilities like wget
 wget http://127.0.0.1:8002/random/10K.1.html
 ```
+
+Alternatively, to run the Nginx server, use one of the following commands:
+
+```
+make start-native-server
+make start-graphene-server
+make SGX=1 start-graphene-server
+```


### PR DESCRIPTION
We are missing Nginx from Jenkins tests for no good reason. This PR adds test targets to Nginx, and the corresponding PR in the main Graphene repo (https://github.com/oscarlab/graphene/pull/1176) adds it to all Jenkins pipelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/55)
<!-- Reviewable:end -->
