### PR TITLE
[Bash] Add trusted libraries required for Ubuntu 18.04

### DIFF
--- a/bash/Makefile
+++ b/bash/Makefile
@@ -35,8 +35,9 @@ endif
 
 # We need to replace Glibc dependencies with Graphene-specific Glibc. The Glibc
 # binaries are already listed in the manifest template, so we can skip them
-# from the ldd results
-GLIBC_DEPS = linux-vdso /lib64/ld-linux-x86-64 libc libm librt libdl libutil libpthread
+# from the ldd results. This list also contains some runtime deps of Bash.
+GLIBC_DEPS = linux-vdso /lib64/ld-linux-x86-64 libc libm librt libdl libutil libpthread \
+             libselinux libpcre libacl libattr
 
 # Listing all Bash dependencies, besides Glibc libraries
 .INTERMEDIATE: $(addsuffix .deps,bash $(PROGRAMS))

--- a/bash/manifest.template
+++ b/bash/manifest.template
@@ -65,6 +65,12 @@ sgx.trusted_files.libnsscompat = file:/lib/x86_64-linux-gnu/libnss_compat.so.2
 sgx.trusted_files.libnssfiles = file:/lib/x86_64-linux-gnu/libnss_files.so.2
 sgx.trusted_files.libnssnis = file:/lib/x86_64-linux-gnu/libnss_nis.so.2
 
+# Additional libs opened by Bash at runtime
+sgx.trusted_files.libselinux1 = file:/lib/x86_64-linux-gnu/libselinux.so.1
+sgx.trusted_files.libpcre = file:/lib/x86_64-linux-gnu/libpcre.so.3
+sgx.trusted_files.libacl = file:/lib/x86_64-linux-gnu/libacl.so.1
+sgx.trusted_files.libattr = file:/lib/x86_64-linux-gnu/libattr.so.1
+
 # Other required libraries
 $(TRUSTED_LIBS)
 


### PR DESCRIPTION
Adds a couple missing libraries required for Ubuntu 18.04. This is to make Linux-SGX pipeline work on Ubuntu 18.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/57)
<!-- Reviewable:end -->
