### PR TITLE
[Curl] Mention dependencies in the readme

### DIFF
--- a/curl/README.md
+++ b/curl/README.md
@@ -2,7 +2,12 @@
 
 This directory contains a Makefile and template manifest to run curl on Graphene. We tested it with
 curl 7.47.0 on Ubuntu 16.04 and with curl 7.58.0 on Ubuntu 18.04. This example uses curl installed
-on the system instead of compiling from source as some of the other examples do.
+on the system instead of compiling from source as some of the other examples do. On Ubuntu 16.04,
+please make sure that `libnss-mdns` is installed and if not, run the following command:
+
+```sh
+sudo apt-get install libnss-mdns
+```
 
 The Makefile and the template manifest contain comments to hopefully make them easier to understand.
 


### PR DESCRIPTION
This is a follow up to https://github.com/oscarlab/graphene/issues/1120 (`libnss-mdns` dependency wasn't mentioned in the readme).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/59)
<!-- Reviewable:end -->
