### PR TITLE
[Redis] Add "start-graphene-server" target for Jenkins and option to use select()

### DIFF
--- a/redis/Makefile
+++ b/redis/Makefile
@@ -7,6 +7,10 @@
 # Any of these invocations clones Redis' git repository and builds Redis in
 # default configuration and in the latest-to-date (5.0.5) version.
 #
+# By default, Redis uses poll/epoll mechanism of Linux. To build Redis with
+# select, use `make USE_SELECT=1`. For correct re-builds, always clean up
+# Redis source code beforehand via `make distclean`.
+#
 # Use `make clean` to remove Graphene-generated files and `make distclean` to
 # additionally remove the cloned Redis git repository.
 
@@ -32,14 +36,23 @@ endif
 
 ############################## REDIS EXECUTABLE ###############################
 
-# Redis is built as usual, without any changes to the build process. The source
-# is cloned from a public GitHub repo (5.0.5 tag) and built via `make`. The
-# result of this build process is the final executable "src/redis-server".
+# Redis is built as usual, without any changes to the build process (except to
+# test select syscall instead of poll/epoll). The source is cloned from a public
+# GitHub repo (5.0.5 tag) and built via `make`. The result of this build process
+# is the final executable "src/redis-server".
 
-$(SRCDIR)/src/redis-server:
+$(SRCDIR)/Makefile:
 	git clone --recursive https://github.com/antirez/redis $(SRCDIR)
 	cd $(SRCDIR) && git checkout $(COMMIT)
+
+ifeq ($(USE_SELECT),1)
+$(SRCDIR)/src/redis-server: $(SRCDIR)/Makefile
+	sed -i 's|#define HAVE_EPOLL 1|/* no HAVE_EPOLL */|g' src/src/config.h
 	$(MAKE) -C $(SRCDIR)
+else
+$(SRCDIR)/src/redis-server: $(SRCDIR)/Makefile
+	$(MAKE) -C $(SRCDIR)
+endif
 
 ################################ REDIS MANIFEST ###############################
 
@@ -83,6 +96,15 @@ redis-server: $(SRCDIR)/src/redis-server
 
 pal_loader:
 	ln -s $(GRAPHENEDIR)/Runtime/pal_loader $@
+
+############################## RUNNING TESTS ##################################
+.PHONY: start-native-server
+start-native-server: all
+	./redis-server --save '' --protected-mode no
+
+.PHONY: start-graphene-server
+start-graphene-server: all
+	./pal_loader redis-server --save '' --protected-mode no
 
 ################################## CLEANUP ####################################
 

--- a/redis/README
+++ b/redis/README
@@ -42,3 +42,8 @@ Notice that we run Redis with two parameters: `save ''` and `protected-mode no`:
   interface. Even though we use the loopback interface (which is always allowed
   in Redis), Graphene hides this information. Therefore, we ask Redis to allow
   clients on all interfaces.
+
+# Redis with Select
+
+By default, Redis uses the epoll mechanism of Linux to monitor client connections.
+To test Redis with select, add `USE_SELECT=1`, e.g., `make SGX=1 USE_SELECT=1`.


### PR DESCRIPTION
To test Redis in Jenkins, this PR adds:
1. `make start-graphene-server` target for Jenkins, similar to web-server examples
2. `make USE_SELECT=1` option to build Redis with `select` instead of `epoll`.

The corresponding PR is https://github.com/oscarlab/graphene/pull/1208.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/60)
<!-- Reviewable:end -->
