### PR TITLE
[LTP] Enable select, pselect, poll, epoll tests

### DIFF
--- a/ltp/README.rst
+++ b/ltp/README.rst
@@ -90,9 +90,6 @@ Flaky tests
    recv01,1
    recv01,2
 
-   Intermittent failure on Linux host
-   poll02,1
-
    Intermittent failure on Linux debug host
    recvmsg01,1
    recvmsg01,2

--- a/ltp/ltp-bug-1023.cfg
+++ b/ltp/ltp-bug-1023.cfg
@@ -157,9 +157,6 @@ skip = yes
 [readv01]
 skip = yes
 
-[select01]
-skip = yes
-
 [sendfile03]
 skip = yes
 

--- a/ltp/ltp-bug-1075.cfg
+++ b/ltp/ltp-bug-1075.cfg
@@ -118,18 +118,6 @@ skip = yes
 [dirtyc0w]
 skip = yes
 
-[epoll_create1_01]
-skip = yes
-
-[epoll_ctl01]
-skip = yes
-
-[epoll_ctl02]
-skip = yes
-
-[epoll_wait02]
-skip = yes
-
 [execl01]
 skip = yes
 
@@ -607,12 +595,6 @@ skip = yes
 [pivot_root01]
 skip = yes
 
-[poll01]
-skip = yes
-
-[poll02]
-skip = yes
-
 [posix_fadvise01]
 skip = yes
 
@@ -665,18 +647,6 @@ skip = yes
 skip = yes
 
 [preadv202_64]
-skip = yes
-
-[pselect01]
-skip = yes
-
-[pselect01_64]
-skip = yes
-
-[pselect03]
-skip = yes
-
-[pselect03_64]
 skip = yes
 
 [ptrace07]
@@ -779,9 +749,6 @@ skip = yes
 skip = yes
 
 [sched_setscheduler03]
-skip = yes
-
-[select04]
 skip = yes
 
 [semctl01]

--- a/ltp/ltp-sgx.cfg
+++ b/ltp/ltp-sgx.cfg
@@ -365,35 +365,13 @@ skip = yes
 [dup3_02]
 skip = yes
 
+# complex test, not all of its checking is implemented in Graphene
 [epoll01]
 skip = yes
 
-[epoll_ctl01]
-must-pass =
-    1
-    3
-
-[epoll_ctl02]
-must-pass =
-    1
-    2
-    5
-    6
-    7
-
+# segfault: uses sigprocmask and sends signals, broken in Graphene
 [epoll_pwait01]
 skip = yes
-
-[epoll_wait01]
-skip = yes
-
-[epoll_wait02]
-skip = yes
-
-[epoll_wait03]
-must-pass =
-    1
-    2
 
 [eventfd01]
 skip = yes
@@ -2179,12 +2157,6 @@ skip = yes
 [pivot_root01]
 skip = yes
 
-[poll01]
-timeout = 60
-
-[poll02]
-skip = yes
-
 [posix_fadvise01]
 skip = yes
 
@@ -2209,6 +2181,7 @@ skip = yes
 [posix_fadvise04_64]
 skip = yes
 
+# segfault: uses sigprocmask and sends signals, broken in Graphene
 [ppoll01]
 skip = yes
 
@@ -2294,23 +2267,19 @@ skip = yes
 [prot_hsymlinks]
 skip = yes
 
-[pselect01]
-skip = yes
-
-[pselect01_64]
-skip = yes
-
+# WORKAROUND: test passes but TWARNs on cleanup of temp dir; bug in Graphene
 [pselect02]
-skip = yes
+must-pass =
+    1
+    2
+    3
 
+# WORKAROUND: test passes but TWARNs on cleanup of temp dir; bug in Graphene
 [pselect02_64]
-skip = yes
-
-[pselect03]
-skip = yes
-
-[pselect03_64]
-skip = yes
+must-pass =
+    1
+    2
+    3
 
 [ptrace01]
 skip = yes
@@ -2683,16 +2652,13 @@ skip = yes
 [sched_yield01]
 skip = yes
 
+# WORKAROUND: test passes but TWARNs on cleanup of temp dir; bug in Graphene
 [select01]
-skip = yes
+must-pass =
+    1
 
-[select02]
-skip = yes
-
+# TBROK: uses mknodat() syscall not implemented in Graphene
 [select03]
-skip = yes
-
-[select04]
 skip = yes
 
 [semctl01]

--- a/ltp/ltp.cfg
+++ b/ltp/ltp.cfg
@@ -280,35 +280,13 @@ skip = yes
 [dup3_02]
 skip = yes
 
+# complex test, not all of its checking is implemented in Graphene
 [epoll01]
 skip = yes
 
-[epoll_ctl01]
-must-pass =
-    1
-    3
-
-[epoll_ctl02]
-must-pass =
-    1
-    2
-    5
-    6
-    7
-
+# segfault: uses sigprocmask and sends signals, broken in Graphene
 [epoll_pwait01]
 skip = yes
-
-[epoll_wait01]
-skip = yes
-
-[epoll_wait02]
-skip = yes
-
-[epoll_wait03]
-must-pass =
-    1
-    2
 
 [eventfd01]
 skip = yes
@@ -1796,9 +1774,6 @@ skip = yes
 [pivot_root01]
 skip = yes
 
-[poll01]
-timeout = 40
-
 [posix_fadvise01]
 skip = yes
 
@@ -1823,6 +1798,7 @@ skip = yes
 [posix_fadvise04_64]
 skip = yes
 
+# segfault: uses sigprocmask and sends signals, broken in Graphene
 [ppoll01]
 skip = yes
 
@@ -1902,11 +1878,19 @@ skip = yes
 [prot_hsymlinks]
 skip = yes
 
+# WORKAROUND: test passes but TWARNs on cleanup of temp dir; bug in Graphene
 [pselect02]
-skip = yes
+must-pass =
+    1
+    2
+    3
 
+# WORKAROUND: test passes but TWARNs on cleanup of temp dir; bug in Graphene
 [pselect02_64]
-skip = yes
+must-pass =
+    1
+    2
+    3
 
 [ptrace01]
 skip = yes
@@ -2251,10 +2235,13 @@ skip = yes
 [sched_setscheduler03]
 skip = yes
 
-[select03]
-skip = yes
+# WORKAROUND: test passes but TWARNs on cleanup of temp dir; bug in Graphene
+[select01]
+must-pass =
+    1
 
-[select04]
+# TBROK: uses mknodat() syscall not implemented in Graphene
+[select03]
 skip = yes
 
 [semctl01]


### PR DESCRIPTION
Graphene now has a reworked select/poll/epoll mechanisms, and corresponding LTP tests pass now (except a couple with issues unrelated to polling).

For more info, see descriptions in https://github.com/oscarlab/graphene/issues/1117, in particular:
- https://github.com/oscarlab/graphene/issues/1117#issuecomment-549095106
- https://github.com/oscarlab/graphene/issues/1117#issuecomment-549188771
- https://github.com/oscarlab/graphene/issues/1117#issuecomment-549563732

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/63)
<!-- Reviewable:end -->
