### PR TITLE
[Apache] Allow SSL/TLS connections

### DIFF
--- a/apache/.gitignore
+++ b/apache/.gitignore
@@ -3,3 +3,5 @@
 /install/*
 /result-*
 /OUTPUT
+/ssl/server.*
+/ssl/ca.*

--- a/apache/Makefile
+++ b/apache/Makefile
@@ -37,7 +37,7 @@ GRAPHENEDEBUG = none
 endif
 
 .PHONY: all
-all: $(INSTALL_DIR)/bin/httpd httpd.manifest pal_loader config testdata
+all: $(INSTALL_DIR)/bin/httpd httpd.manifest pal_loader config testdata ssldata
 ifeq ($(SGX),1)
 all: httpd.manifest.sgx httpd.sig httpd.token
 endif
@@ -47,7 +47,8 @@ endif
 
 $(INSTALL_DIR)/bin/httpd: $(HTTPD_SRC)/configure
 	cd $(HTTPD_SRC) && ./configure --prefix=$(abspath $(INSTALL_DIR)) \
-		--with-mpm=prefork --enable-mpms-shared='prefork worker event'
+		--with-mpm=prefork --enable-mpms-shared='prefork worker event' \
+		--enable-ssl
 	cd $(HTTPD_SRC) && $(MAKE)
 	cd $(HTTPD_SRC) && $(MAKE) install
 
@@ -78,6 +79,7 @@ httpd-modules: $(INSTALL_DIR)/conf/httpd.conf
 		awk '{print "$(INSTALL_DIR)/" $$3}' > $@
 	@echo $(INSTALL_DIR)/modules/mod_mpm_worker.so >> $@
 	@echo $(INSTALL_DIR)/modules/mod_mpm_event.so  >> $@
+	@echo $(INSTALL_DIR)/modules/mod_ssl.so        >> $@
 
 # Listing all the Apache dependencies, besides Glibc libraries
 .INTERMEDIATE: httpd-ldd
@@ -136,23 +138,17 @@ pal_loader:
 	ln -s $(GRAPHENEDIR)/Runtime/pal_loader $@
 
 # Apache configuration and test data
-#
-# The following changes are made in httpd.conf (copied as httpd-graphene.conf):
-# - Remove "Listen ..." (Use a command-line option instead)
-# - Remove "User ..." and "Group ..."
-# - Comment "LoadModule mpm_prefork_module ...." (Use a command-line option instead)
-# - Uncomment "EnableMMAP off"
-# - Uncomment "EnableSendfile on"
-# - Add configuration for the Prefork and Worker MPMs
 
 .PHONY: config
-config: $(INSTALL_DIR)/conf/httpd-graphene.conf
+config: $(INSTALL_DIR)/conf/httpd-graphene.conf $(INSTALL_DIR)/conf/extra/httpd-ssl-graphene.conf
 
 $(INSTALL_DIR)/conf/httpd-graphene.conf: $(INSTALL_DIR)/conf/httpd.conf
 	sed -e "s|^Listen |#Listen |g" \
 		-e "s|^User |#User |g" \
 		-e "s|^Group |#Group |g" \
 		-e "s|^LoadModule mpm_prefork|#LoadModule mpm_prefork|g" \
+		-e "s|^#LoadModule ssl_module|LoadModule ssl_module|g" \
+		-e "s|^#Include conf/extra/httpd-ssl.conf|Include conf/extra/httpd-ssl-graphene.conf|g" \
 		-e "s|#EnableMMAP off|EnableMMAP off|g" \
 		-e "s|#EnableSendfile on|EnableSendfile on|g" \
 	$< > $@
@@ -170,6 +166,13 @@ $(INSTALL_DIR)/conf/httpd-graphene.conf: $(INSTALL_DIR)/conf/httpd.conf
     MaxSpareThreads          75\n\
     ThreadsPerChild          25\n\
 </IfModule>\n" >> $@
+
+$(INSTALL_DIR)/conf/extra/httpd-ssl-graphene.conf: $(INSTALL_DIR)/conf/extra/httpd-ssl.conf
+	sed -e "s|^Listen 443|Listen 127.0.0.1:8443|g" \
+		-e "s|^<VirtualHost _default_:443>|<VirtualHost 127.0.0.1:8443>|g" \
+		-e "s|^ServerName www.example.com:443|ServerName www.example.com:8443|g" \
+		-e "s|^SSLSessionCache|#SSLSessionCache|g" \
+	$< > $@
 
 # HTTP docs:
 # Generating random HTML files in $(INSTALL_DIR)/htdocs/random
@@ -191,6 +194,19 @@ $(RANDOM_DIR)/%.html:
 
 .PHONY: testdata
 testdata: $(TEST_DATA)
+
+# SSL data: key and x.509 self-signed certificate (to test SSL/TLS)
+
+$(INSTALL_DIR)/conf/server.crt: ssl/ca_config.conf
+	openssl genrsa -out ssl/ca.key 2048
+	openssl req -x509 -new -nodes -key ssl/ca.key -sha256 -days 1024 -out ssl/ca.crt -config ssl/ca_config.conf
+	openssl genrsa -out ssl/server.key 2048
+	openssl req -new -key ssl/server.key -out ssl/server.csr -config ssl/ca_config.conf
+	openssl x509 -req -days 360 -in ssl/server.csr -CA ssl/ca.crt -CAkey ssl/ca.key -CAcreateserial -out ssl/server.crt
+	cp -f ssl/* $(INSTALL_DIR)/conf/
+
+.PHONY: ssldata
+ssldata: $(INSTALL_DIR)/conf/server.crt
 
 # Commands for running Apache
 #
@@ -260,3 +276,4 @@ clean:
 .PHONY: distclean
 distclean: clean
 	$(RM) -r $(HTTPD_SRC).tar.gz $(HTTPD_SRC) $(INSTALL_DIR)
+	$(RM) ssl/server.* ssl/ca.*

--- a/apache/README.md
+++ b/apache/README.md
@@ -10,7 +10,8 @@ them to understand the requirements for Apache running under Graphene-SGX.
 We build Apache from the source code instead of using an existing installation.
 On Ubuntu 16.04, please make sure that the following packages are installed:
 ```sh
-sudo apt-get install -y build-essential flex libapr1-dev libaprutil1-dev libpcre2-dev apache2-utils
+sudo apt-get install -y build-essential flex libapr1-dev libaprutil1-dev libpcre2-dev \
+                        apache2-utils libssl-dev
 ```
 
 # Quick Start
@@ -19,23 +20,27 @@ sudo apt-get install -y build-essential flex libapr1-dev libaprutil1-dev libpcre
 # build Apache and the final manifest
 make SGX=1
 
-# run original Apache against a benchmark (benchmark-http.sh, uses ab)
+# run original Apache against HTTP and HTTPS benchmarks (benchmark-http.sh, uses ab)
 make start-native-server &
 ./benchmark-http.sh 127.0.0.1:8001
+./benchmark-http.sh https://127.0.0.1:8443
 kill -SIGINT %%
 
-# run Apache in non-SGX Graphene against a benchmark
+# run Apache in non-SGX Graphene against HTTP and HTTPS benchmarks
 make start-graphene-server &
 ./benchmark-http.sh 127.0.0.1:8001
+./benchmark-http.sh https://127.0.0.1:8443
 kill -SIGINT %%
 
-# run Apache in Graphene-SGX against a benchmark
+# run Apache in Graphene-SGX against HTTP and HTTPS benchmarks
 SGX=1 make start-graphene-server &
 ./benchmark-http.sh 127.0.0.1:8001
+./benchmark-http.sh https://127.0.0.1:8443
 kill -SIGINT %%
 
 # you can also test the server using other utilities like wget
 wget http://127.0.0.1:8001/random/10K.1.html
+wget https://127.0.0.1:8443/random/10K.1.html
 ```
 
 # Running Apache with Different MPMs

--- a/apache/httpd.manifest.template
+++ b/apache/httpd.manifest.template
@@ -36,6 +36,11 @@ fs.mount.usr.type = chroot
 fs.mount.usr.path = /usr
 fs.mount.usr.uri = file:/usr
 
+# Host-level directory (/etc) required by Apache (needed mostly for SSL/TLS)
+fs.mount.etc.type = chroot
+fs.mount.etc.path = /etc
+fs.mount.etc.uri = file:/etc
+
 # Mount the current working directory
 fs.mount.cwd.type = chroot
 fs.mount.cwd.path = $(INSTALL_DIR_ABSPATH)
@@ -73,6 +78,9 @@ sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
 # Other libraries required by Apache
 sgx.trusted_files.libgcc_s = file:/lib/x86_64-linux-gnu/libgcc_s.so.1
 sgx.trusted_files.nss_files = file:/lib/x86_64-linux-gnu/libnss_files.so.2
+sgx.trusted_files.libnsscompat = file:/lib/x86_64-linux-gnu/libnss_compat.so.2
+sgx.trusted_files.libnssnis  = file:/lib/x86_64-linux-gnu/libnss_nis.so.2
+sgx.trusted_files.libnsl = file:/lib/x86_64-linux-gnu/libnsl.so.1
 
 # Apache modules and dependencies
 $(HTTPD_TRUSTED_MODS)
@@ -80,7 +88,12 @@ $(HTTPD_TRUSTED_LIBS)
 
 # Apache configuration (trusted)
 sgx.trusted_files.conf1 = file:$(INSTALL_DIR)/conf/httpd-graphene.conf
-sgx.trusted_files.conf2 = file:$(INSTALL_DIR)/conf/mime.types
+sgx.trusted_files.conf2 = file:$(INSTALL_DIR)/conf/extra/httpd-ssl-graphene.conf
+sgx.trusted_files.conf3 = file:$(INSTALL_DIR)/conf/mime.types
+
+# Apache SSL/TLS files (trusted)
+sgx.trusted_files.server_cert = file:$(INSTALL_DIR)/conf/server.crt
+sgx.trusted_files.server_key  = file:$(INSTALL_DIR)/conf/server.key
 
 # Apache HTTP documents (trusted)
 # We only specify those documents used in our tests/benchmarks.
@@ -89,3 +102,13 @@ sgx.trusted_files.htdocs2 = file:$(INSTALL_DIR)/htdocs/random/10K.1.html
 
 # Apache logs directory (untrusted and allowed, since log files are not security-critical)
 sgx.allowed_files.logs = file:$(INSTALL_DIR)/logs
+
+# Name Service Switch (NSS) files, see 'man nsswitch.conf'
+sgx.allowed_files.nsswitch  = file:/etc/nsswitch.conf
+sgx.allowed_files.ethers    = file:/etc/ethers
+sgx.allowed_files.hosts     = file:/etc/hosts
+sgx.allowed_files.group     = file:/etc/group
+sgx.allowed_files.passwd    = file:/etc/passwd
+
+# getaddrinfo(3) configuration file, see 'man gai.conf'
+sgx.allowed_files.gaiconf   = file:/etc/gai.conf

--- a/apache/ssl/ca_config.conf
+++ b/apache/ssl/ca_config.conf
@@ -1,0 +1,16 @@
+[ req ]
+default_bits       = 4096
+default_md         = sha512
+default_keyfile    = example.com.key
+prompt             = no
+encrypt_key        = no
+distinguished_name = req_distinguished_name
+
+[ req_distinguished_name ]
+countryName            = "XX"             # C=
+localityName           = "XXXXX"          # L=
+organizationName       = "My Company"     # O=
+organizationalUnitName = "Department"     # OU=
+commonName             = "*.example.com"  # CN=
+emailAddress           = "me@example.com" # email
+

--- a/common_tools/benchmark-http.sh
+++ b/common_tools/benchmark-http.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-## On Ubuntu, this script requires apache2-utils for the ab binary.
+# On Ubuntu, this script requires apache2-utils for the ab binary.
+#
 # Run like: ./benchmark-http.sh host:port
+#
+# It also works with HTTPS, e.g., ./benchmark-http.sh https://localhost:8443
 
 declare -A THROUGHPUTS
 declare -A LATENCIES
@@ -21,8 +24,8 @@ do
     for CONCURRENCY in $CONCURRENCY_LIST
     do
         rm -f OUTPUT
-        echo "ab $OPTIONS -n $REQUESTS -c $CONCURRENCY http://$DOWNLOAD_HOST/$DOWNLOAD_FILE"
-        ab $OPTIONS -n $REQUESTS -c $CONCURRENCY http://$DOWNLOAD_HOST/$DOWNLOAD_FILE > OUTPUT || exit $?
+        echo "ab $OPTIONS -n $REQUESTS -c $CONCURRENCY $DOWNLOAD_HOST/$DOWNLOAD_FILE"
+        ab $OPTIONS -n $REQUESTS -c $CONCURRENCY $DOWNLOAD_HOST/$DOWNLOAD_FILE > OUTPUT || exit $?
 
         sleep 5
 


### PR DESCRIPTION
This commit updates the Apache httpd example with SSL/TLS mode using the mod_ssl module. The private key and x.509 self-signed cert are generated automatically in the Makefile. Benchmark is updated to test SSL/TLS as well.

Corresponding PR is https://github.com/oscarlab/graphene/pull/1293.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/68)
<!-- Reviewable:end -->
