### PR TITLE
[NodeJS] Increase enclave size to 2GB so that NodeJS doesn't fail

### DIFF
--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -32,9 +32,10 @@ fs.mount.lib3.type = chroot
 fs.mount.lib3.path = /usr/lib/x86_64-linux-gnu
 fs.mount.lib3.uri = file:/usr/lib/x86_64-linux-gnu
 
-# Set enclave size (somewhat arbitrarily) to 1GB. Recall that SGX v1 requires
-# to specify enclave size at enclave creation time.
-sgx.enclave_size = 1G
+# Set enclave size to 2GB; NodeJS expects around 1.7GB of heap on startup,
+# see e.g. https://github.com/nodejs/node/issues/13018.
+# Recall that SGX v1 requires to specify enclave size at enclave creation time.
+sgx.enclave_size = 2G
 
 # Set maximum number of in-enclave threads (somewhat arbitrarily) to 8. Recall
 # that SGX v1 requires to specify the maximum number of simultaneous threads at


### PR DESCRIPTION
NodeJS expects around 1.7GB of heap on startup. Previously, enclave size was set to only 1GB, which led to NodeJS probabilistically complaining about "Fatal process OOM in heap setup".

Corresponding PR is https://github.com/oscarlab/graphene/pull/1360.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/74)
<!-- Reviewable:end -->
