### PR TITLE
[LTP] Disable tests that fail on Glibc 2.31

### DIFF
--- a/ltp/ltp-sgx.cfg
+++ b/ltp/ltp-sgx.cfg
@@ -3088,9 +3088,9 @@ skip = yes
 [setsockopt03]
 skip = yes
 
+# this test fails on Glibc 2.31; see https://github.com/linux-test-project/ltp/issues/646
 [settimeofday01]
-must-pass =
-    3
+skip = yes
 
 [settimeofday02]
 skip = yes

--- a/ltp/ltp.cfg
+++ b/ltp/ltp.cfg
@@ -2626,9 +2626,9 @@ skip = yes
 must-pass =
     2
 
+# this test fails on Glibc 2.31; see https://github.com/linux-test-project/ltp/issues/646
 [settimeofday01]
-must-pass =
-    3
+skip = yes
 
 [settimeofday02]
 skip = yes
@@ -2922,6 +2922,7 @@ skip = yes
 [syscall01]
 timeout = 80
 
+# Graphene doesn't emulate all sysconf parameters, so we disable the ones not currently emulated
 [sysconf01]
 must-pass =
     1
@@ -2935,7 +2936,6 @@ must-pass =
     9
     10
     12
-    13
     14
     15
     16


### PR DESCRIPTION
This commit disables tests that loudly fail on Glibc 2.31:

- settimeofday01 -- it never worked before in Graphene anyway, and Glibc 2.31 code doesn't properly sanitize function arguments. Again, the combination of upstream LTP and Glibc 2.31 is broken. See https://github.com/linux-test-project/ltp/issues/646.

- sysconf01 -- worked by accident, now that Glibc 2.31 loudly complains about unimplemented _SC_XOPEN_CRYPT, it fails.

Generally, some LTP tests must be re-written to work with Glibc 2.31.

Corresponding PR is https://github.com/oscarlab/graphene/pull/1369.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/76)
<!-- Reviewable:end -->
