### PR TITLE
[Bash] Remove unnecessary `sleep 1` from the check

### DIFF
--- a/bash/Makefile
+++ b/bash/Makefile
@@ -115,12 +115,10 @@ regression: all
 	@mkdir -p scripts/testdir
 
 	./pal_loader bash.manifest -c "ls" > OUTPUT
-	@sleep 1  # to make sure Bash child processes flush output under Graphene-SGX
 	@grep -q "Makefile" OUTPUT && echo "[ Success 1/6 ]"
 	@rm OUTPUT
 
 	./pal_loader bash.manifest -c "cd scripts && bash bash_test.sh 1" > OUTPUT
-	@sleep 1
 	@grep -q "hello 1" OUTPUT      && echo "[ Success 2/6 ]"
 	@grep -q "createdfile" OUTPUT  && echo "[ Success 3/6 ]"
 	@grep -q "somefile" OUTPUT     && echo "[ Success 4/6 ]"
@@ -128,7 +126,6 @@ regression: all
 	@rm OUTPUT
 
 	./pal_loader bash.manifest -c "cd scripts && bash bash_test.sh 3" > OUTPUT
-	@sleep 1
 	@grep -q "hello 3" OUTPUT      && echo "[ Success 6/6 ]"
 	@rm OUTPUT
 


### PR DESCRIPTION
Previously, `bash -c ls` inside Graphene resulted in a detached child
`ls` process (because execve emulation created an intermediate process
that silently exited, confusing make). To alleviate this issue, we
introduced a workaround of `sleep 1` to wait for the child to exit.
With new changes to Graphene, the intermediate process sticks around,
and make correctly waits for the child to finish everything.

Corresponding PR is https://github.com/oscarlab/graphene/pull/1370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene-tests/77)
<!-- Reviewable:end -->
